### PR TITLE
Show scrollbar on header overflow

### DIFF
--- a/tilde.css
+++ b/tilde.css
@@ -7,6 +7,13 @@ body {
     font-size: 1.0em;
 }
 
+pre {
+    display: block;
+    white-space: pre;
+    word-break: break-all;
+    overflow-x: auto;
+}
+
 .date {
     font-weight: bold;
 }


### PR DESCRIPTION
Currently the header text "tilde.insitute" will overflow on small
screens, instead we ask it show scrollbar.